### PR TITLE
Add test for clearing hostkeys

### DIFF
--- a/tests/test_hostkeys.py
+++ b/tests/test_hostkeys.py
@@ -96,7 +96,7 @@ class HostKeysTest (unittest.TestCase):
         for key in hostdict:
             i += 1
         self.assertEqual(2, i)
-        
+
     def test_4_dict_set(self):
         hostdict = paramiko.HostKeys('hostfile.temp')
         key = paramiko.RSAKey(data=decodebytes(keyblob))
@@ -107,7 +107,7 @@ class HostKeysTest (unittest.TestCase):
         }
         hostdict['fake.example.com'] = {}
         hostdict['fake.example.com']['ssh-rsa'] = key
-        
+
         self.assertEqual(3, len(hostdict))
         self.assertEqual(2, len(list(hostdict.values())[0]))
         self.assertEqual(1, len(list(hostdict.values())[1]))
@@ -128,3 +128,12 @@ class HostKeysTest (unittest.TestCase):
             pass # Good
         else:
             assert False, "Entry was not deleted from HostKeys on delitem!"
+
+    def test_clear(self):
+        hostdict = paramiko.HostKeys()
+        hh = '|1|BMsIC6cUIP2zBuXR3t2LRcJYjzM=|hpkJMysjTk/+zzUUzxQEa2ieq6c='
+        key = paramiko.RSAKey(data=decodebytes(keyblob))
+        hostdict.add(hh, 'ssh-rsa', key)
+        self.assertEqual(1, len(list(hostdict)))
+        hostdict.clear()
+        self.assertEqual(0, len(list(hostdict)))


### PR DESCRIPTION
Add a test that asserts clearing a hostkeys dictionary works properly

Partly fixes #25 